### PR TITLE
Notice minimum required reactor-core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ ReactorDebugAgent.processExistingClasses();
 > 
 > Use it only if you see that some call-sites are not instrumented.
 
+_Requires minimally `reactor-core:3.2.6`_
+
 
 ### Limitations
 Java 8 users **must use JDK** instead of JRE:  

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ReactorDebugAgent.processExistingClasses();
 > 
 > Use it only if you see that some call-sites are not instrumented.
 
-_Requires minimally `reactor-core:3.2.6`_
+_Works with Reactor Core version 3.2.6 or higher_
 
 
 ### Limitations


### PR DESCRIPTION
On 3.2.3 for example it could fail in runtime with `NoClassDefFoundError: reactor/core/publisher/FluxOnAssembly$AssemblySnapshot`