### PR TITLE
Handle null-returning methods correctly. Fixes #7

### DIFF
--- a/reactor-tools/src/main/java/reactor/tools/agent/ReactorDebugAgent.java
+++ b/reactor-tools/src/main/java/reactor/tools/agent/ReactorDebugAgent.java
@@ -149,7 +149,13 @@ public class ReactorDebugAgent {
 					}
 				};
 
-				cr.accept(classVisitor, 0);
+				try {
+					cr.accept(classVisitor, 0);
+				}
+				catch (Throwable e) {
+					e.printStackTrace();
+					throw e;
+				}
 
 				if (!changed.get()) {
 					return null;

--- a/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
+++ b/reactor-tools/src/test/java/reactor/tools/agent/ReactorDebugAgentTest.java
@@ -77,9 +77,21 @@ public class ReactorDebugAgentTest {
 				.startsWith("GroupedFlux.map ⇢ reactor.tools.agent.ReactorDebugAgentTest.shouldWorkWithGroupedFlux(ReactorDebugAgentTest.java:" + (baseline + 1));
 	}
 
+	// See https://github.com/reactor/reactor-tools/issues/7
+	@Test
+	public void shouldHandleNullReturnValue() {
+		Mono<Integer> mono = methodReturningNullMono();
+
+		assertThat(mono).isNull();
+	}
+
 	static final int methodReturningMonoBaseline = getBaseline();
 	private Mono<Integer> methodReturningMono(Mono<Integer> mono) {
 		return mono;
+	}
+
+	private Mono<Integer> methodReturningNullMono() {
+		return null;
 	}
 
 	private static int getBaseline() {


### PR DESCRIPTION
Before this fix, a method that returns `null` instead of an instance
of some core publisher was throwing an NPE because it was trying to
checkpoint the result without checking for `null`.